### PR TITLE
Update camera perspective

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -167,7 +167,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 30246070}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071067}
-  m_LocalPosition: {x: 0, y: 20, z: 0}
+  m_LocalPosition: {x: 0, y: 25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_Children: []

--- a/Assets/Scripts/FollowPlayer.cs
+++ b/Assets/Scripts/FollowPlayer.cs
@@ -4,13 +4,23 @@ using System.Collections;
 [RequireComponent (typeof (Transform))]
 public class FollowPlayer : MonoBehaviour {
 	public GameObject player;
+	private Vector3 startingPosition;
 	Transform cameraTransform;
 
 	void Start () {
 		cameraTransform = GetComponent<Transform> ();
+		startingPosition = cameraTransform.position;
 	}
 
 	void Update () {
-		cameraTransform.position = new Vector3 (player.transform.position.x, cameraTransform.position.y, player.transform.position.z);
+		cameraTransform.position = cameraPosition();
+	}
+
+	Vector3 cameraPosition () {
+		return new Vector3 (
+			player.transform.position.x + startingPosition.x,
+			cameraTransform.position.y,
+			player.transform.position.z + startingPosition.z
+		);
 	}
 }


### PR DESCRIPTION
- Raise camera higher above the player, now that its model is bigger (and closer to the camera)
- Take initial camera position in `FollowPlayer` script, so that changing the camera position in Unity editor does not reset the camera's position to an arbitrary setting