### PR TITLE
Fix collisions between player and enemies not triggering

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -47,7 +47,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &110266
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -109,7 +109,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &114966
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -186,7 +186,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &125090
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -218,7 +218,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &127096
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -280,7 +280,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &142600
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -509,7 +509,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &194374
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -617,13 +617,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 125090}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.7027289, y: -0.7114578, z: -0.0000000070640453, w: 0.0000000072759576}
+  m_LocalPosition: {x: -0.110238515, y: 0.01864061, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 89.292694}
   m_Children: []
-  m_Father: {fileID: 412762}
-  m_RootOrder: 0
+  m_Father: {fileID: 474748}
+  m_RootOrder: 1
 --- !u!4 &412762
 Transform:
   m_ObjectHideFlags: 1
@@ -635,12 +635,6 @@ Transform:
   m_LocalScale: {x: 20, y: 20, z: 20}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 409976}
-  - {fileID: 439814}
-  - {fileID: 451296}
-  - {fileID: 478950}
-  - {fileID: 477000}
-  - {fileID: 475832}
   - {fileID: 460224}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -696,7 +690,8 @@ Transform:
   m_LocalPosition: {x: -2.806792e-17, y: 0.01, z: 5.517208e-21}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: -0.123799995, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 478950}
   m_Father: {fileID: 481432}
   m_RootOrder: 2
 --- !u!4 &437746
@@ -732,12 +727,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 110266}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.6985378, y: -0.7155732, z: -0.000000007135896, w: 0.0000000073923734}
+  m_LocalPosition: {x: -0.109486274, y: -0.022644086, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 88.6196}
   m_Children: []
-  m_Father: {fileID: 412762}
+  m_Father: {fileID: 463866}
   m_RootOrder: 1
 --- !u!4 &442842
 Transform:
@@ -760,13 +755,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 127096}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.0007638312, y: -0.0007638312, z: 0.70710635, w: 0.70710635}
+  m_LocalPosition: {x: 0.06, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0.123799995, y: 0, z: 90}
   m_Children: []
-  m_Father: {fileID: 412762}
-  m_RootOrder: 2
+  m_Father: {fileID: 460224}
+  m_RootOrder: 3
 --- !u!4 &451316
 Transform:
   m_ObjectHideFlags: 1
@@ -823,8 +818,9 @@ Transform:
   - {fileID: 497726}
   - {fileID: 477850}
   - {fileID: 406906}
+  - {fileID: 451296}
   m_Father: {fileID: 412762}
-  m_RootOrder: 6
+  m_RootOrder: 0
 --- !u!4 &463866
 Transform:
   m_ObjectHideFlags: 1
@@ -837,6 +833,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 90, y: 179.87619, z: 88.6196}
   m_Children:
   - {fileID: 433808}
+  - {fileID: 439814}
   m_Father: {fileID: 481432}
   m_RootOrder: 1
 --- !u!4 &474748
@@ -851,6 +848,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 90, y: 179.87619, z: 89.292694}
   m_Children:
   - {fileID: 442842}
+  - {fileID: 409976}
   m_Father: {fileID: 481432}
   m_RootOrder: 0
 --- !u!4 &475832
@@ -859,26 +857,26 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 142600}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.7025598, y: -0.71162474, z: 3.0013325e-11, w: -5.820766e-11}
+  m_LocalPosition: {x: -0.059866883, y: -0.010768345, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 89.265495}
   m_Children: []
-  m_Father: {fileID: 412762}
-  m_RootOrder: 5
+  m_Father: {fileID: 477850}
+  m_RootOrder: 1
 --- !u!4 &477000
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 114966}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.06, y: -0.009793035, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
   m_Children: []
-  m_Father: {fileID: 412762}
-  m_RootOrder: 4
+  m_Father: {fileID: 497726}
+  m_RootOrder: 1
 --- !u!4 &477850
 Transform:
   m_ObjectHideFlags: 1
@@ -891,6 +889,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: -0.123799995, y: -180, z: -0.7345}
   m_Children:
   - {fileID: 409516}
+  - {fileID: 475832}
   m_Father: {fileID: 460224}
   m_RootOrder: 1
 --- !u!4 &478072
@@ -912,15 +911,15 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 194374}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 1.1641534e-10, y: 0, z: 0.000000089406974, w: 1}
+  m_LocalPosition: {x: 0, y: -0.12, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 480256}
   - {fileID: 415830}
-  m_Father: {fileID: 412762}
-  m_RootOrder: 3
+  m_Father: {fileID: 435578}
+  m_RootOrder: 0
 --- !u!4 &480256
 Transform:
   m_ObjectHideFlags: 1
@@ -1016,6 +1015,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0.123799995, y: 0, z: -180}
   m_Children:
   - {fileID: 439244}
+  - {fileID: 477000}
   m_Father: {fileID: 460224}
   m_RootOrder: 0
 --- !u!4 &499170

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -9,7 +9,6 @@ GameObject:
   m_Component:
   - 4: {fileID: 477148}
   - 33: {fileID: 3337828}
-  - 65: {fileID: 6580652}
   - 23: {fileID: 2349712}
   m_Layer: 8
   m_Name: Torchlight
@@ -63,23 +62,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &112710
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 476242}
-  - 33: {fileID: 3367976}
-  - 23: {fileID: 2353418}
-  m_Layer: 0
-  m_Name: Ground
-  m_TagString: Player
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &113630
 GameObject:
   m_ObjectHideFlags: 1
@@ -127,6 +109,23 @@ GameObject:
   - 4: {fileID: 422592}
   m_Layer: 8
   m_Name: HandR2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &115708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 420222}
+  - 33: {fileID: 3317702}
+  - 23: {fileID: 2381354}
+  m_Layer: 0
+  m_Name: Ground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -286,13 +285,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &128342
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 462342}
   - 137: {fileID: 13753334}
+  - 64: {fileID: 6404170}
   m_Layer: 8
   m_Name: LegRight1
   m_TagString: Untagged
@@ -334,13 +334,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &137954
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 413290}
   - 137: {fileID: 13768738}
+  - 64: {fileID: 6400042}
   m_Layer: 8
   m_Name: ArmRight1
   m_TagString: Untagged
@@ -380,13 +381,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &163230
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 454630}
   - 137: {fileID: 13714848}
+  - 64: {fileID: 6430680}
   m_Layer: 8
   m_Name: Body1
   m_TagString: Untagged
@@ -411,13 +413,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &168936
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 454680}
   - 137: {fileID: 13760192}
+  - 64: {fileID: 6474158}
   m_Layer: 8
   m_Name: Head1
   m_TagString: Untagged
@@ -475,13 +478,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &174608
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 418104}
   - 137: {fileID: 13778962}
+  - 64: {fileID: 6424796}
   m_Layer: 8
   m_Name: LegLeft1
   m_TagString: Untagged
@@ -623,7 +627,6 @@ GameObject:
   m_Component:
   - 4: {fileID: 464672}
   - 33: {fileID: 3322900}
-  - 65: {fileID: 6514156}
   - 23: {fileID: 2384222}
   m_Layer: 8
   m_Name: Torchlight
@@ -695,13 +698,14 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &191076
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 436430}
   - 137: {fileID: 13746490}
+  - 64: {fileID: 6445882}
   m_Layer: 8
   m_Name: ArmLeft1
   m_TagString: Untagged
@@ -809,13 +813,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 137954}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.6985378, y: -0.7155732, z: -0.000000007135896, w: 0.0000000073923734}
+  m_LocalPosition: {x: -0.109486274, y: -0.022644086, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 88.6196}
   m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 5
+  m_Father: {fileID: 470048}
+  m_RootOrder: 2
 --- !u!4 &416602
 Transform:
   m_ObjectHideFlags: 1
@@ -835,13 +839,26 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 174608}
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.06, y: -0.009793035, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+  m_Children: []
+  m_Father: {fileID: 457816}
+  m_RootOrder: 1
+--- !u!4 &420222
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 115708}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 482168}
-  m_RootOrder: 6
+  m_RootOrder: 1
 --- !u!4 &422592
 Transform:
   m_ObjectHideFlags: 1
@@ -869,7 +886,7 @@ Transform:
   m_Children:
   - {fileID: 434126}
   m_Father: {fileID: 441018}
-  m_RootOrder: 0
+  m_RootOrder: 1
 --- !u!4 &427118
 Transform:
   m_ObjectHideFlags: 1
@@ -931,13 +948,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 191076}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.7027289, y: -0.7114578, z: -0.0000000070640453, w: 0.0000000072759576}
+  m_LocalPosition: {x: -0.110238515, y: 0.01864061, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 89.292694}
   m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 4
+  m_Father: {fileID: 477012}
+  m_RootOrder: 2
 --- !u!4 &440958
 Transform:
   m_ObjectHideFlags: 1
@@ -963,6 +980,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: -0.123799995, y: -180, z: -0.7345}
   m_Children:
+  - {fileID: 462342}
   - {fileID: 426806}
   m_Father: {fileID: 479554}
   m_RootOrder: 1
@@ -976,7 +994,8 @@ Transform:
   m_LocalPosition: {x: -2.806792e-17, y: 0.01, z: 5.517208e-21}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: -0.123799995, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 454680}
   m_Father: {fileID: 448100}
   m_RootOrder: 2
 --- !u!4 &448100
@@ -1014,26 +1033,26 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 163230}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.0007638312, y: -0.0007638312, z: 0.70710635, w: 0.70710635}
+  m_LocalPosition: {x: 0.06, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0.123799995, y: 0, z: 90}
   m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 7
+  m_Father: {fileID: 479554}
+  m_RootOrder: 3
 --- !u!4 &454680
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 168936}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 1.1641534e-10, y: 0, z: 0.000000089406974, w: 1}
+  m_LocalPosition: {x: 0, y: -0.12, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 8
+  m_Father: {fileID: 441992}
+  m_RootOrder: 0
 --- !u!4 &457100
 Transform:
   m_ObjectHideFlags: 1
@@ -1060,6 +1079,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0.123799995, y: 0, z: -180}
   m_Children:
   - {fileID: 401060}
+  - {fileID: 418104}
   m_Father: {fileID: 479554}
   m_RootOrder: 0
 --- !u!4 &459866
@@ -1081,13 +1101,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 128342}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.7025598, y: -0.71162474, z: 3.0013325e-11, w: -5.820766e-11}
+  m_LocalPosition: {x: -0.059866883, y: -0.010768345, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 89.265495}
   m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 3
+  m_Father: {fileID: 441018}
+  m_RootOrder: 0
 --- !u!4 &462924
 Transform:
   m_ObjectHideFlags: 1
@@ -1131,6 +1151,7 @@ Transform:
   m_Children:
   - {fileID: 472842}
   - {fileID: 484426}
+  - {fileID: 413290}
   m_Father: {fileID: 448100}
   m_RootOrder: 1
 --- !u!4 &470726
@@ -1203,19 +1224,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 440958}
   m_RootOrder: 0
---- !u!4 &476242
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 112710}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.05, z: 0.5}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
-  m_Father: {fileID: 482168}
-  m_RootOrder: 1
 --- !u!4 &476774
 Transform:
   m_ObjectHideFlags: 1
@@ -1242,6 +1250,7 @@ Transform:
   m_Children:
   - {fileID: 462924}
   - {fileID: 401484}
+  - {fileID: 436430}
   m_Father: {fileID: 448100}
   m_RootOrder: 0
 --- !u!4 &477148
@@ -1272,6 +1281,7 @@ Transform:
   - {fileID: 457816}
   - {fileID: 441018}
   - {fileID: 457100}
+  - {fileID: 454630}
   m_Father: {fileID: 482168}
   m_RootOrder: 2
 --- !u!4 &482168
@@ -1286,14 +1296,8 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 471652}
-  - {fileID: 476242}
+  - {fileID: 420222}
   - {fileID: 479554}
-  - {fileID: 462342}
-  - {fileID: 436430}
-  - {fileID: 413290}
-  - {fileID: 418104}
-  - {fileID: 454630}
-  - {fileID: 454680}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!4 &484426
@@ -1392,32 +1396,6 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingOrder: 0
---- !u!23 &2353418
-MeshRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 112710}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
 --- !u!23 &2357978
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -1464,6 +1442,32 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!23 &2381354
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 115708}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 1
+  m_ReflectionProbeUsage: 1
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
   m_MinimumChartSize: 4
@@ -1531,6 +1535,13 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 177738}
   m_Mesh: {fileID: 4300000, guid: c1232b0a1b78ddf44bd877453fb7a84c, type: 3}
+--- !u!33 &3317702
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 115708}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &3321562
 MeshFilter:
   m_ObjectHideFlags: 1
@@ -1566,13 +1577,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 103582}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!33 &3367976
-MeshFilter:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 112710}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &5440042
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1588,30 +1592,78 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 84
   m_CollisionDetection: 0
---- !u!65 &6514156
-BoxCollider:
+--- !u!64 &6400042
+MeshCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 186196}
+  m_GameObject: {fileID: 137954}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!65 &6580652
-BoxCollider:
+  m_Convex: 1
+  m_Mesh: {fileID: 4300006, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &6404170
+MeshCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 103582}
+  m_GameObject: {fileID: 128342}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Convex: 1
+  m_Mesh: {fileID: 4300010, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &6424796
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 174608}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300008, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &6430680
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 163230}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300000, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &6445882
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 191076}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300004, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &6474158
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 168936}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300002, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
 --- !u!95 &9526786
 Animator:
   serializedVersion: 3

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -439,6 +439,102 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &685935338 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 137954, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!1 &685935339 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 191076, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!1 &685935340 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 128342, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!64 &685935341
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935338}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300006, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &685935342
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935339}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300004, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!64 &685935343
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935340}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300010, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!1 &685935344 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 174608, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!64 &685935345
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935344}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300008, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!1 &685935346 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 163230, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!64 &685935347
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935346}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300000, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
+--- !u!1 &685935348 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 168936, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+  m_PrefabInternal: {fileID: 685935337}
+--- !u!64 &685935349
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 685935348}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300002, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
 --- !u!1 &789731540
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -436,7 +436,9 @@ Prefab:
       propertyPath: m_TagString
       value: Untagged
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6580652, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+    - {fileID: 6514156, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
   m_IsPrefabParent: 0
 --- !u!1 &685935338 stripped

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -188,7 +188,7 @@ MonoBehaviour:
 --- !u!1 &94032492 stripped
 GameObject:
   m_PrefabParentObject: {fileID: 114082, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
+  m_PrefabInternal: {fileID: 563895601}
 --- !u!1 &296772625
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,7 +345,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
---- !u!1001 &685935337
+--- !u!1001 &563895601
 Prefab:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -384,159 +384,17 @@ Prefab:
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 2384222, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 248509450b92ab5428b6e160e128272d, type: 2}
     - target: {fileID: 2349712, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 248509450b92ab5428b6e160e128272d, type: 2}
-    - target: {fileID: 477012, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0.5144672
-      objectReference: {fileID: 0}
-    - target: {fileID: 477012, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0.51980925
-      objectReference: {fileID: 0}
-    - target: {fileID: 477012, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0.48465762
-      objectReference: {fileID: 0}
-    - target: {fileID: 477012, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.47982177
-      objectReference: {fileID: 0}
-    - target: {fileID: 477012, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 86
-      objectReference: {fileID: 0}
-    - target: {fileID: 470048, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0.51140505
-      objectReference: {fileID: 0}
-    - target: {fileID: 470048, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0.52282214
-      objectReference: {fileID: 0}
-    - target: {fileID: 470048, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0.48746762
-      objectReference: {fileID: 0}
-    - target: {fileID: 470048, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.47696668
-      objectReference: {fileID: 0}
-    - target: {fileID: 470048, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 86
-      objectReference: {fileID: 0}
-    - target: {fileID: 112710, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-      propertyPath: m_TagString
-      value: Untagged
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 6580652, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-    - {fileID: 6514156, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+    - target: {fileID: 2384222, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 248509450b92ab5428b6e160e128272d, type: 2}
+    m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &685935338 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 137954, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!1 &685935339 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 191076, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!1 &685935340 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 128342, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!64 &685935341
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935338}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300006, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
---- !u!64 &685935342
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935339}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300004, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
---- !u!64 &685935343
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935340}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300010, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
---- !u!1 &685935344 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 174608, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!64 &685935345
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935344}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300008, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
---- !u!1 &685935346 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 163230, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!64 &685935347
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935346}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300000, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
---- !u!1 &685935348 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 168936, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
-  m_PrefabInternal: {fileID: 685935337}
---- !u!64 &685935349
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 685935348}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300002, guid: 11de9d883ba29e7408300ad1c2cc424b, type: 3}
 --- !u!1 &789731540
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -432,6 +432,10 @@ Prefab:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 86
       objectReference: {fileID: 0}
+    - target: {fileID: 112710, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 594ac1638f7da224db2974760b32f56b, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 [RequireComponent (typeof (Transform))]
-[RequireComponent (typeof (Rigidbody))]
 public class PlayerController : MonoBehaviour {
 
 	private float movementSpeed = 10f;
@@ -12,12 +11,10 @@ public class PlayerController : MonoBehaviour {
 	private float rotationDeadzone = 0.25f;
 
 	Transform playerTransform;
-	Rigidbody playerRigidbody;
 
 	// Use this for initialization
 	void Start () {
 		playerTransform = GetComponent<Transform> ();
-		playerRigidbody = GetComponent<Rigidbody> ();
 		ResetPosition ();
 	}
 
@@ -41,7 +38,7 @@ public class PlayerController : MonoBehaviour {
 	void Move(Vector2 movementInput) {
 		Vector3 movement = new Vector3 (movementInput.x * movementSpeed * Time.deltaTime,  0f, movementInput.y * movementSpeed * Time.deltaTime);
 
-		playerRigidbody.MovePosition (playerTransform.position + movement);
+		playerTransform.position = playerTransform.position + movement;
 	}
 
 	void Rotate(Vector2 rotationInput, float deltaTime) {


### PR DESCRIPTION
- Add mesh colliders to player limbs to properly trigger collisions on player rigidbody
- Arm mesh colliders were not rotated with the mesh, for both player and enemies
- Making limbs children of their corresponding root bones solves the issue