### PR TITLE
Fix missed collisions between bullets and enemies

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -1046,7 +1046,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 84
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
 --- !u!64 &6423128
 MeshCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/PistolBullet.prefab
+++ b/Assets/Prefabs/PistolBullet.prefab
@@ -5,13 +5,14 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 499130}
-  - 33: {fileID: 3302568}
-  - 23: {fileID: 2396292}
-  - 114: {fileID: 11434096}
-  - 64: {fileID: 6442876}
+  - component: {fileID: 499130}
+  - component: {fileID: 3302568}
+  - component: {fileID: 2396292}
+  - component: {fileID: 11434096}
+  - component: {fileID: 54171054465348340}
+  - component: {fileID: 136812410295611078}
   m_Layer: 8
   m_Name: PistolBullet
   m_TagString: Bullet
@@ -28,10 +29,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 20, y: 20, z: 20}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2396292
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -41,17 +42,22 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 6d819cd7190b96141a6695ab4511fa73, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
@@ -64,18 +70,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 145268}
-  m_Mesh: {fileID: 4300002, guid: 93375713b9d6e4a4ab7099069b571d4d, type: 3}
---- !u!64 &6442876
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 145268}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
   m_Mesh: {fileID: 4300002, guid: 93375713b9d6e4a4ab7099069b571d4d, type: 3}
 --- !u!114 &11434096
 MonoBehaviour:
@@ -99,3 +93,31 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 145268}
   m_IsPrefabParent: 1
+--- !u!54 &54171054465348340
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 145268}
+  serializedVersion: 2
+  m_Mass: 0.01
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 2
+--- !u!136 &136812410295611078
+CapsuleCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 145268}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.00238724
+  m_Height: 0.006
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.0024, z: 0}

--- a/Assets/Scripts/BulletMovement.cs
+++ b/Assets/Scripts/BulletMovement.cs
@@ -2,16 +2,6 @@
 using System.Collections;
 
 public class BulletMovement : MonoBehaviour {
-	private float movementSpeed = 25f;
-
-	void Update () {
-		gameObject.transform.position += nextPosition(Time.deltaTime);
-	}
-
-	Vector3 nextPosition(float deltaTime) {
-		return (gameObject.transform.up * deltaTime * movementSpeed);
-	}
-
 	void OnBecameInvisible () {
 		Destroy (gameObject);
 	}

--- a/Assets/Scripts/EnemyBulletCollision.cs
+++ b/Assets/Scripts/EnemyBulletCollision.cs
@@ -12,11 +12,11 @@ public class EnemyBulletCollision : MonoBehaviour {
 		playerScript = playerGameObject.GetComponent<PlayerScript> ();
 	}
 
-	void OnTriggerEnter (Collider other) {
-		if (other.gameObject.tag == bulletTag) {
+	void OnCollisionEnter (Collision collision) {
+		if (collision.gameObject.tag == bulletTag) {
 			playerScript.player.incrementEnemyKills ();
 			Destroy (gameObject);
-			Destroy (other.gameObject);
+			Destroy (collision.gameObject);
 		}
 	}
 }

--- a/Assets/Scripts/GunBehaviour.cs
+++ b/Assets/Scripts/GunBehaviour.cs
@@ -9,6 +9,7 @@ public class GunBehaviour : MonoBehaviour {
 	private float lastShotInterval;
 	private Vector3 bulletStartPosition = new Vector3(0f, 0.01375f, 0f);
     private Vector3 bulletCasingStartPosition = new Vector3(0.00134f, 0.02091f, -0.00174f);
+	private float bulletThrust = 20f;
     private float bulletCasingThrust = 0.01f;
 	private float bulletCasingMinimumThrustDirectionUp = 2f;
 	private float bulletCasingMaximumThrustDirectionUp = 4f;
@@ -36,7 +37,8 @@ public class GunBehaviour : MonoBehaviour {
 	}
 
 	void Fire () {
-        Instantiate(bulletPrefab, gameObject.transform.TransformPoint(bulletStartPosition), BulletRotation());
+		GameObject bullet = (GameObject)Instantiate(bulletPrefab, gameObject.transform.TransformPoint(bulletStartPosition), BulletRotation());
+		bullet.GetComponent<Rigidbody>().AddForce(bullet.transform.up * bulletThrust, ForceMode.Force);
 
         GameObject bulletCasing = (GameObject)Instantiate(bulletCasingPrefab, gameObject.transform.TransformPoint(bulletCasingStartPosition), BulletRotation());
         bulletCasing.GetComponent<Rigidbody>().AddForce(BulletCasingForce() * bulletCasingThrust, ForceMode.Impulse);


### PR DESCRIPTION
- Add rigidbody to bullets
- Change bullet collider to a primitive capsule collider for better performance
- Change bullet collider to non-trigger so bullet behaves like a solid object
- Add force to bullet's rigidbody for movement
- Set bullet's rigidbody collision detection to "continuous dynamic"
- Set enemy's rigidbody collision detection to "continuous"

Fixes #27 